### PR TITLE
feat: partial WASM support (only Ed25519 signatures verification)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,8 +10,6 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.53.0
-          - nightly
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -32,8 +30,6 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.53.0
-          - nightly
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -63,6 +59,15 @@ jobs:
         with:
           command: test
           args: --all-features
+
+  test-wasm:
+    name: WASM Test
+    needs: check-all-features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jetli/wasm-pack-action@v0.3.0
+      - run: wasm-pack test --headless --chrome --release
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "x509-parser"
 version = "0.13.1"
 description = "Parser for the X.509 v3 format (RFC 5280 certificates)"
 license = "MIT/Apache-2.0"
-keywords = ["X509","Certificate","parser","nom"]
+keywords = ["X509", "Certificate", "parser", "nom"]
 authors = ["Pierre Chifflier <chifflier@wzdftpd.net>"]
 homepage = "https://github.com/rusticata/x509-parser"
 repository = "https://github.com/rusticata/x509-parser.git"
@@ -12,22 +12,22 @@ readme = "README.md"
 edition = "2018"
 
 include = [
-  "CHANGELOG.md",
-  "LICENSE-*",
-  "README.md",
-  ".gitignore",
-  ".travis.yml",
-  "Cargo.toml",
-  "src/*.rs",
-  "src/extensions/*.rs",
-  "src/validate/*.rs",
-  "tests/*.rs",
-  "assets/*.crl",
-  "assets/*.csr",
-  "assets/*.der",
-  "assets/*.pem",
-  "assets/crl-ext/*.der",
-  "examples/*.rs"
+    "CHANGELOG.md",
+    "LICENSE-*",
+    "README.md",
+    ".gitignore",
+    ".travis.yml",
+    "Cargo.toml",
+    "src/*.rs",
+    "src/extensions/*.rs",
+    "src/validate/*.rs",
+    "tests/*.rs",
+    "assets/*.crl",
+    "assets/*.csr",
+    "assets/*.der",
+    "assets/*.pem",
+    "assets/crl-ext/*.der",
+    "examples/*.rs"
 ]
 
 [package.metadata.docs.rs]
@@ -40,14 +40,33 @@ verify = ["ring"]
 validate = []
 
 [dependencies]
-asn1-rs = { version = "0.5", features=["datetime"] }
+asn1-rs = { version = "0.5", features = ["datetime"] }
 base64 = "0.13"
 data-encoding = "2.2.1"
 lazy_static = "1.4"
 nom = "7.0"
-oid-registry = { version="0.6", features=["crypto", "x509"] }
+oid-registry = { version = "0.6", features = ["crypto", "x509"] }
 rusticata-macros = "4.0"
-ring = { version="0.16.11", optional=true }
-der-parser = { version = "8.1.0", features=["bigint"] }
+der-parser = { version = "8.1.0", features = ["bigint"] }
 thiserror = "1.0.2"
-time = { version="0.3.7", features=["formatting"] }
+
+[dependencies.ring]
+git = "https://github.com/briansmith/ring.git"
+rev = "0f3bf003"
+# requires the latest version to have Ed25519 support on WASM
+features = ["wasm32_unknown_unknown_js"]
+optional = true
+
+[target.'cfg(target_family = "wasm")'.dependencies.chrono]
+version = "=0.4.19"
+features = ["wasmbind", "std", "clock"]
+default-features = false
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies.chrono]
+version = "=0.4.19"
+default-features = false
+features = ["std", "clock"]
+
+[dev-dependencies]
+x509-parser = { path = ".", features = ["verify"] }
+wasm-bindgen-test = "0.3"

--- a/src/certification_request.rs
+++ b/src/certification_request.rs
@@ -13,6 +13,8 @@ use der_parser::*;
 use nom::Offset;
 #[cfg(feature = "verify")]
 use oid_registry::*;
+#[cfg(feature = "verify")]
+use ring::signature::VerificationAlgorithm;
 use std::collections::HashMap;
 
 /// Certification Signing Request (CSR)
@@ -46,19 +48,61 @@ impl<'a> X509CertificationRequest<'a> {
         let spki = &self.certification_request_info.subject_pki;
         let signature_alg = &self.signature_algorithm.algorithm;
         // identify verification algorithm
-        let verification_alg: &dyn signature::VerificationAlgorithm =
+        let verification_alg: &dyn VerificationAlgorithm =
             if *signature_alg == OID_PKCS1_SHA1WITHRSA {
-                &signature::RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    &signature::RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY
+                }
+                #[cfg(target_family = "wasm")]
+                {
+                    return Err(X509Error::SignatureUnsupportedAlgorithm);
+                }
             } else if *signature_alg == OID_PKCS1_SHA256WITHRSA {
-                &signature::RSA_PKCS1_2048_8192_SHA256
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    &signature::RSA_PKCS1_2048_8192_SHA256
+                }
+                #[cfg(target_family = "wasm")]
+                {
+                    return Err(X509Error::SignatureUnsupportedAlgorithm);
+                }
             } else if *signature_alg == OID_PKCS1_SHA384WITHRSA {
-                &signature::RSA_PKCS1_2048_8192_SHA384
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    &signature::RSA_PKCS1_2048_8192_SHA384
+                }
+                #[cfg(target_family = "wasm")]
+                {
+                    return Err(X509Error::SignatureUnsupportedAlgorithm);
+                }
             } else if *signature_alg == OID_PKCS1_SHA512WITHRSA {
-                &signature::RSA_PKCS1_2048_8192_SHA512
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    &signature::RSA_PKCS1_2048_8192_SHA512
+                }
+                #[cfg(target_family = "wasm")]
+                {
+                    return Err(X509Error::SignatureUnsupportedAlgorithm);
+                }
             } else if *signature_alg == OID_SIG_ECDSA_WITH_SHA256 {
-                &signature::ECDSA_P256_SHA256_ASN1
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    &signature::ECDSA_P256_SHA256_ASN1
+                }
+                #[cfg(target_family = "wasm")]
+                {
+                    return Err(X509Error::SignatureUnsupportedAlgorithm);
+                }
             } else if *signature_alg == OID_SIG_ECDSA_WITH_SHA384 {
-                &signature::ECDSA_P384_SHA384_ASN1
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    &signature::ECDSA_P384_SHA384_ASN1
+                }
+                #[cfg(target_family = "wasm")]
+                {
+                    return Err(X509Error::SignatureUnsupportedAlgorithm);
+                }
             } else if *signature_alg == OID_SIG_ED25519 {
                 &signature::ED25519
             } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ pub struct NidError;
 pub type X509Result<'a, T> = IResult<&'a [u8], T, X509Error>;
 
 /// An error that can occur while parsing or validating a certificate.
-#[derive(Clone, Debug, PartialEq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum X509Error {
     #[error("generic error")]
     Generic,
@@ -66,6 +66,7 @@ pub enum X509Error {
 
     #[error("BER error: {0}")]
     Der(#[from] BerError),
+
     #[error("nom error: {0:?}")]
     NomError(ErrorKind),
 }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1187,7 +1187,11 @@ fn der_read_critical(i: &[u8]) -> BerResult<bool> {
 mod tests {
     use super::*;
 
+    use wasm_bindgen_test::*;
+    wasm_bindgen_test_configure!(run_in_browser);
+
     #[test]
+    #[wasm_bindgen_test]
     fn test_keyusage_flags() {
         let ku = KeyUsage { flags: 98 };
         assert!(!ku.digital_signature());
@@ -1202,6 +1206,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_extensions1() {
         use der_parser::oid;
         let crt = crate::parse_x509_certificate(include_bytes!("../../assets/extension1.der"))
@@ -1319,6 +1324,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_extensions2() {
         use der_parser::oid;
         let crt = crate::parse_x509_certificate(include_bytes!("../../assets/extension2.der"))
@@ -1352,6 +1358,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test]
     fn test_extensions_crl_distribution_points() {
         // Extension not present
         {

--- a/tests/pem.rs
+++ b/tests/pem.rs
@@ -1,10 +1,14 @@
 use std::io::Cursor;
+use wasm_bindgen_test::*;
 use x509_parser::pem::{parse_x509_pem, Pem};
 use x509_parser::{parse_x509_certificate, x509::X509Version};
+
+wasm_bindgen_test_configure!(run_in_browser);
 
 static IGCA_PEM: &[u8] = include_bytes!("../assets/IGC_A.pem");
 
 #[test]
+#[wasm_bindgen_test]
 fn test_x509_parse_pem() {
     let (rem, pem) = parse_x509_pem(IGCA_PEM).expect("PEM parsing failed");
     // println!("{:?}", pem);
@@ -19,6 +23,7 @@ fn test_x509_parse_pem() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn test_pem_read() {
     let reader = Cursor::new(IGCA_PEM);
     let (pem, bytes_read) = Pem::read(reader).expect("Reading PEM failed");
@@ -32,6 +37,7 @@ fn test_pem_read() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn test_pem_not_pem() {
     let bytes = vec![0x1, 0x2, 0x3, 0x4, 0x5];
     let reader = Cursor::new(bytes);
@@ -42,6 +48,7 @@ fn test_pem_not_pem() {
 static NO_END: &[u8] = include_bytes!("../assets/no_end.pem");
 
 #[test]
+#[wasm_bindgen_test]
 fn test_pem_no_end() {
     let reader = Cursor::new(NO_END);
     let res = Pem::read(reader);

--- a/tests/readcsr.rs
+++ b/tests/readcsr.rs
@@ -1,10 +1,14 @@
 use oid_registry::{OID_PKCS1_SHA256WITHRSA, OID_SIG_ECDSA_WITH_SHA256, OID_X509_COMMON_NAME};
+use wasm_bindgen_test::*;
 use x509_parser::prelude::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
 
 const CSR_DATA_EMPTY_ATTRIB: &[u8] = include_bytes!("../assets/csr-empty-attributes.csr");
 const CSR_DATA: &[u8] = include_bytes!("../assets/test.csr");
 
 #[test]
+#[wasm_bindgen_test]
 fn read_csr_empty_attrib() {
     let (rem, csr) =
         X509CertificationRequest::from_der(CSR_DATA_EMPTY_ATTRIB).expect("could not parse CSR");
@@ -17,6 +21,7 @@ fn read_csr_empty_attrib() {
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn read_csr_with_san() {
     let der = pem::parse_x509_pem(CSR_DATA).unwrap().1;
     let (rem, csr) =
@@ -52,8 +57,10 @@ fn read_csr_with_san() {
     }
 }
 
-#[cfg(feature = "verify")]
+// TODO: does not work in WASM for any signature alg except ed25519...but we don't need anything else ATM
+// #[wasm_bindgen_test]
 #[test]
+#[cfg(feature = "verify")]
 fn read_csr_verify() {
     let der = pem::parse_x509_pem(CSR_DATA).unwrap().1;
     let (_, csr) = X509CertificationRequest::from_der(&der.contents).expect("could not parse CSR");

--- a/tests/run_all_fuzz_files.rs
+++ b/tests/run_all_fuzz_files.rs
@@ -23,7 +23,6 @@ fn parse_dir(name: &str) {
 
 fn parse_file(entry: &DirEntry) -> std::io::Result<()> {
     let path = entry.path();
-    // println!("{:?}", entry.path());
     let data = fs::read(path).unwrap();
     let _ = parse_x509_certificate(&data);
     Ok(())

--- a/tests/test01.rs
+++ b/tests/test01.rs
@@ -1,6 +1,10 @@
 use nom::bytes::complete::take;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]
+#[wasm_bindgen_test]
 fn test01() {
     let data = b"0\x88\xff\xff\xff\xff\xff\xff\xff\xff00\x0f\x02\x000\x00\x00\x00\x00\x00\x0000\x0f\x00\xff\x0a\xbb\xff";
     let _ = x509_parser::parse_x509_certificate(data);
@@ -8,11 +12,12 @@ fn test01() {
 
 fn parser02(input: &[u8]) -> nom::IResult<&[u8], ()> {
     let (_hdr, input) = take(1_usize)(input)?;
-    let (_data, input) = take(18_446_744_073_709_551_615_usize)(input)?;
+    let (_data, input) = take(usize::MAX)(input)?;
     Ok((input, ()))
 }
 
 #[test]
+#[wasm_bindgen_test]
 fn test02() {
     let data = b"0\x88\xff\xff\xff\xff\xff\xff\xff\xff00\x0f\x02\x000\x00\x00\x00\x00\x00\x0000\x0f\x00\xff\x0a\xbb\xff";
     let _ = parser02(data);

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -1,5 +1,9 @@
 #![cfg(feature = "verify")]
 
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
 use x509_parser::parse_x509_certificate;
 
 static CA_DER: &[u8] = include_bytes!("../assets/IGC_A.der");
@@ -7,6 +11,7 @@ static CA_LETSENCRYPT_X3: &[u8] = include_bytes!("../assets/lets-encrypt-x3-cros
 static CERT_DER: &[u8] = include_bytes!("../assets/certificate.der");
 
 #[test]
+#[wasm_bindgen_test]
 fn test_signature_verification() {
     // for a root CA, verify self-signature
     let (_, x509_ca) = parse_x509_certificate(CA_DER).expect("could not parse certificate");
@@ -26,6 +31,7 @@ fn test_signature_verification() {
 static ED25519_DER: &[u8] = include_bytes!("../assets/ed25519.der");
 
 #[test]
+#[wasm_bindgen_test]
 fn test_signature_verification_ed25519() {
     // this certificate is self-signed
     let (_, x509_ca) = parse_x509_certificate(ED25519_DER).expect("could not parse certificate");


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Support WASM (only Ed25519 at the moment)
* other signature algorithms provided by `ring` do not well on WASM for the moment
* replace `time` (no WASM support) by `chrono`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
